### PR TITLE
Bump to new version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 dist: xenial
 sudo: true
 
@@ -28,7 +29,7 @@ deploy:
   provider: pypi
   on:
     branch: master
-    python: "3.7"
+    python: "3.8"
   distributions: "sdist bdist_wheel"
   skip_existing: true
   username: "nielstron"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Two interfaces to BLNet exist and both are supported:
 - Webinterface  - Class BLnetWeb
 - BLNet-Direct protocol [1] - Class BLNETDirect
 
+However, as of now, there is no testing on the BLNet-Direct protocol *of any kind*, so enabling it is discouraged until the interface is fixed.
+Parsing the data via the web interface is the preferred way of accessing the BLNet for now.
+
 The class BLNET is a wrapper around the two classes. When initializing the class, the two interfaces can be activated/deactivated. 
 BLNetDirect provides 'analog', 'digital',  'speed', 'energy', 'power', whereas BLnetWeb supports 'analog' and 'digital' only.
 If both are active, BLNetDirect has priority.

--- a/pyblnet/__init__.py
+++ b/pyblnet/__init__.py
@@ -10,7 +10,7 @@ try:
 except ImportError as e:
     warnings.warn(ImportWarning(e))
 
-VERSION = (0, 8, 0)
+VERSION = (0, 8, 1)
 
 __version__ = '.'.join([str(i) for i in VERSION])
 __author__ = 'nielstron'

--- a/pyblnet/blnet.py
+++ b/pyblnet/blnet.py
@@ -41,7 +41,7 @@ class BLNET(object):
                  timeout=5,
                  max_retries=5,
                  use_web=True,
-                 use_ta=True):
+                 use_ta=False):
         """
         If a connection (Web or TA/Direct) should not be used,
         set the corresponding use_* to False

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords='python uvr1611 blnet technische alternative home automation iot',
     python_requires='>=3',


### PR DESCRIPTION
- Disable unstable and untested TCP direct connection per default
- discourage its usage
- include python 3.8